### PR TITLE
Move Guzzle Client initialization to GuzzlePromisesTransport

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Symfony errors Catcher module for Hawk.so",
   "keywords": ["hawk", "php", "error", "catcher", "monolog", "symfony"],
   "type": "library",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "MIT",
   "require": {
     "php": "^7.2 || ^8.0",

--- a/src/DependencyInjection/HawkExtension.php
+++ b/src/DependencyInjection/HawkExtension.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace HawkBundle\DependencyInjection;
 
-use GuzzleHttp\Client;
 use HawkBundle\Catcher;
 use HawkBundle\Monolog\Handler;
 use HawkBundle\Transport\GuzzlePromisesTransport;
@@ -33,8 +32,7 @@ class HawkExtension extends Extension
         $container->setParameter('hawk.integration_token', $config['integration_token']);
 
         // Register TransportInterface
-        $container->register(GuzzlePromisesTransport::class)
-            ->setArgument('$client', new Reference(Client::class));
+        $container->register(GuzzlePromisesTransport::class);
 
         // Register Catcher
         $container->register(Catcher::class)

--- a/src/Transport/GuzzlePromisesTransport.php
+++ b/src/Transport/GuzzlePromisesTransport.php
@@ -21,12 +21,10 @@ class GuzzlePromisesTransport implements TransportInterface
 
     /**
      * CurlTransport constructor.
-     *
-     * @param Client $client
      */
-    public function __construct(Client $client)
+    public function __construct()
     {
-        $this->client = $client;
+        $this->client = new Client();
     }
 
     /**


### PR DESCRIPTION
This refactor reduces the complexity of HawkExtension and enhances flexibility in the transport implementation.