### PR TITLE
Add support for beforeSend service configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ public function test()
 ```
 
 ### Example: BeforeSendService Class
+
+If you want to process or modify error data before sending it to Hawk, you can define a custom service by implementing the `BeforeSendServiceInterface`.
+
 ```php
 <?php
 
@@ -105,14 +108,20 @@ use HawkBundle\Service\BeforeSendServiceInterface;
 
 class BeforeSendService implements BeforeSendServiceInterface
 {
-    public function __invoke(EventPayload $eventPayload): EventPayload
+    public function __invoke(EventPayload $eventPayload): ?EventPayload
     {
         $user = $eventPayload->getUser();
         
+        // Modify or add additional data to the error report
         if (!empty($user['email'])){
             unset($user['email']);
         
             $eventPayload->setUser($user);
+        }
+        
+        // Return null to prevent the event from being sent to Hawk
+        if ($eventPayload->getContext()['skip_sending'] ?? false) {
+            return null;
         }
 
         return $eventPayload;

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Create a configuration file at `config/packages/hawk.yaml` with the following co
 ```yaml
 hawk:
   integration_token: '%env(HAWK_TOKEN)%'
+
+  # Optional: Configure a custom beforeSend service
+  before_send_service: 'App\Hawk\BeforeSendService'
 ```
 
 In the `config/packages/monolog.yaml` file, specify the handler settings under the appropriate section (`dev` or `prod`):
@@ -87,6 +90,32 @@ public function test()
         // The code where you need to catch the error
     } catch (\Exception $exception) {
         $this->catcher->sendException($exception);
+    }
+}
+```
+
+### Example: BeforeSendService Class
+```php
+<?php
+
+namespace App\Hawk;
+
+use Hawk\EventPayload;
+use HawkBundle\Service\BeforeSendServiceInterface;
+
+class BeforeSendService implements BeforeSendServiceInterface
+{
+    public function __invoke(EventPayload $eventPayload): EventPayload
+    {
+        $user = $eventPayload->getUser();
+        
+        if (!empty($user['email'])){
+            unset($user['email']);
+        
+            $eventPayload->setUser($user);
+        }
+
+        return $eventPayload;
     }
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Symfony errors Catcher module for Hawk.so",
   "keywords": ["hawk", "php", "error", "catcher", "monolog", "symfony"],
   "type": "library",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "license": "MIT",
   "require": {
     "php": "^7.2 || ^8.0",

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -17,10 +17,13 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-            ->scalarNode('integration_token')
-            ->isRequired()
-            ->cannotBeEmpty()
-            ->end()
+                ->scalarNode('integration_token')
+                    ->isRequired()
+                    ->cannotBeEmpty()
+                ->end()
+                ->scalarNode('before_send_service')
+                    ->defaultNull()
+                ->end()
             ->end()
         ;
 

--- a/src/DependencyInjection/HawkExtension.php
+++ b/src/DependencyInjection/HawkExtension.php
@@ -6,6 +6,7 @@ namespace HawkBundle\DependencyInjection;
 
 use HawkBundle\Catcher;
 use HawkBundle\Monolog\Handler;
+use HawkBundle\Service\BeforeSendServiceInterface;
 use HawkBundle\Transport\GuzzlePromisesTransport;
 use Monolog\Logger;
 use Symfony\Component\Config\FileLocator;
@@ -34,9 +35,19 @@ class HawkExtension extends Extension
         // Register TransportInterface
         $container->register(GuzzlePromisesTransport::class);
 
+        $options = ['integrationToken' => $config['integration_token']];
+
+        if (
+            isset($config['before_send_service'])
+            && class_exists($config['before_send_service'])
+            && is_subclass_of($config['before_send_service'], BeforeSendServiceInterface::class)
+        ) {
+            $options['beforeSend'] = new Reference($config['before_send_service']);
+        }
+
         // Register Catcher
         $container->register(Catcher::class)
-            ->setArgument('$options', ['integrationToken' => $config['integration_token']])
+            ->setArgument('$options', $options)
             ->setArgument('$transport', new Reference(GuzzlePromisesTransport::class));
 
         // Register Monolog\Handler

--- a/src/Service/BeforeSendServiceInterface.php
+++ b/src/Service/BeforeSendServiceInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HawkBundle\Service;
+
+interface BeforeSendServiceInterface
+{
+
+}


### PR DESCRIPTION
This PR introduces the ability to configure a custom `beforeSend` service in the HawkBundle configuration. The 'beforeSend' service is used for additional processing of error data before it is sent to the Hawk error tracking service.

Changes:
- Added `before_send_service` parameter to HawkBundle configuration in 'hawk.yaml'.

This feature allows users to easily extend and modify the behavior of error handling in the HawkBundle, providing more flexibility in integrating with other parts of the application.